### PR TITLE
Finish refactor of DesignerEditor shortcuts

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1128,9 +1128,13 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Confirm cancel from ListData property editor without saving data.")
   String listDataConcelConfirm();
 
-  @DefaultMessage("Click to Add Row Data")
+  @DefaultMessage("Add an item")
   @Description("Button to add a new blank row in the ListData property editor")
   String listDataAddRowButton();
+
+  @DefaultMessage("{0} items")
+  @Description("Count of rows shown in the header of the ListData property editor")
+  String listDataItemCount(int count);
 
 
   // Used in boxes/ViewerBox.java

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -828,6 +828,14 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Keyboard shortcut action: open the keyboard shortcuts dialog")
   String shortcutOpenDialog();
 
+  @DefaultMessage("Move Component Up")
+  @Description("Keyboard shortcut action: move the selected component up in the tree")
+  String shortcutMoveComponentUp();
+
+  @DefaultMessage("Move Component Down")
+  @Description("Keyboard shortcut action: move the selected component down in the tree")
+  String shortcutMoveComponentDown();
+
   @DefaultMessage("Library")
   @Description("Name of Library link")
   String libraryMenuItem();

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
@@ -82,7 +82,7 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
     U extends SimplePalettePanel, V extends ComponentDatabaseInterface,
     W extends SimpleVisibleComponentsPanel<T>>
     extends SimpleEditor implements DesignerChangeListener, ComponentDatabaseChangeListener,
-        PropertyChangeListener, KeyDownHandler {
+        PropertyChangeListener {
 
   protected static class FileContentHolder {
     private String content;
@@ -103,6 +103,8 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
   public static final String EDITOR_TYPE = DesignerEditor.class.getSimpleName();
 
   private static final Logger LOG = Logger.getLogger(DesignerEditor.class.getName());
+
+  private static final int KEY_SLASH = 191;
 
   protected final List<ComponentDatabaseChangeListener> componentDatabaseChangeListeners
       = new ArrayList<>();
@@ -151,12 +153,87 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
   protected final SimpleNonVisibleComponentsPanel<T> nonVisibleComponentsPanel;
 
   static {
+    ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "focus_search", MESSAGES.shortcutFocusSearch(), KEY_SLASH, null, (editor) -> {
+      if (editor.palettePanel.shouldSuppressShortcuts()) {
+        return false;
+      }
+      // TODO
+      editor.palettePanel.focusSearchBox();
+      return true;
+    });
     ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "focus_tree", MESSAGES.shortcutFocusTree(), KeyCodes.KEY_T, null, (editor) -> {
       if (editor.palettePanel.shouldSuppressShortcuts()) {
         return false;
       }
       SourceStructureBox.getSourceStructureBox().getSourceStructureExplorer().getTree().setFocus(true);
       return true;
+    });
+    ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "focus_viewer", MESSAGES.shortcutFocusViewer(), KeyCodes.KEY_V, null, (editor) -> {
+      if (editor.palettePanel.shouldSuppressShortcuts()) {
+        return false;
+      }
+      editor.getVisibleComponentsPanel().focusCheckbox();
+      return true;
+    });
+    ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "focus_properties", MESSAGES.shortcutFocusProperties(), KeyCodes.KEY_P, null, (editor) -> {
+      if (editor.palettePanel.shouldSuppressShortcuts()) {
+        return false;
+      }
+      editor.designProperties.focusFirstCategory();
+      return true;
+    });
+    ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "focus_media", MESSAGES.shortcutFocusMedia(), KeyCodes.KEY_M, null, (editor) -> {
+      if (editor.palettePanel.shouldSuppressShortcuts()) {
+        return false;
+      }
+      AssetListBox.getAssetListBox().getAssetList().getTree().setFocus(true);
+      return true;
+    });
+    ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "move_component_up", MESSAGES.shortcutMoveComponentUp(), KeyCodes.KEY_UP, new int[] { KeyCodes.KEY_ALT }, (editor) -> {
+      if (editor.palettePanel.shouldSuppressShortcuts()) {
+        return false;
+      }
+      MockComponent selectedComponent = editor.root.getLastSelectedComponent();
+      if (selectedComponent != null) {
+        MockContainer parent = selectedComponent.getContainer();
+        if (parent != null) {
+          // Snapshot sibling list before any mutation so indices are stable.
+          List<MockComponent> siblings = new ArrayList<>(parent.getChildren());
+          int posInParent = siblings.indexOf(selectedComponent);
+          SourceStructureExplorerItem source = selectedComponent.getSourceStructureExplorerItem();
+          if (posInParent > 0) {
+            MockComponent prev = siblings.get(posInParent - 1);
+            source.moveTo(prev.getSourceStructureExplorerItem(), -1);
+          } else if (!parent.isRoot()) {
+            source.moveTo(parent.getSourceStructureExplorerItem(), -1);
+          }
+          return true;
+        }
+      }
+      return false;
+    });
+    ShortcutRegistry.getInstance().registerViewShortcut(DesignerEditor.class, "move_component_down", MESSAGES.shortcutMoveComponentDown(), KeyCodes.KEY_DOWN, new int[] { KeyCodes.KEY_ALT }, (editor) -> {
+      if (editor.palettePanel.shouldSuppressShortcuts()) {
+        return false;
+      }
+      MockComponent selectedComponent = editor.root.getLastSelectedComponent();
+      if (selectedComponent != null) {
+        MockContainer parent = selectedComponent.getContainer();
+        if (parent != null) {
+          // Snapshot sibling list before any mutation so indices are stable.
+          List<MockComponent> siblings = new ArrayList<>(parent.getChildren());
+          int posInParent = siblings.indexOf(selectedComponent);
+          SourceStructureExplorerItem source = selectedComponent.getSourceStructureExplorerItem();
+          if (posInParent < siblings.size() - 1) {
+            MockComponent next = siblings.get(posInParent + 1);
+            source.moveTo(next.getSourceStructureExplorerItem(), 1);
+          } else if (!parent.isRoot()) {
+            source.moveTo(parent.getSourceStructureExplorerItem(), 1);
+          }
+          return true;
+        }
+      }
+      return false;
     });
   }
 
@@ -192,7 +269,6 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
     initWidget(componentsPanel);
     setSize("100%", "100%");
     registerNativeListeners();
-    RootPanel.get().addDomHandler(this, KeyDownEvent.getType());
   }
 
   @Override
@@ -712,49 +788,6 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
     }
 
     return mockComponent;
-  }
-
-  @Override
-  public void onKeyDown(KeyDownEvent event) {
-    if (!isActiveEditor()) {
-      return;  // Not the active editor
-    }
-    if (event.isAltKeyDown()) {
-      MockComponent selectedComponent = root.getLastSelectedComponent();
-      if (selectedComponent != null) {
-        MockContainer parent = selectedComponent.getContainer();
-        if (parent != null) {
-          // Snapshot sibling list before any mutation so indices are stable.
-          List<MockComponent> siblings = new ArrayList<>(parent.getChildren());
-          int posInParent = siblings.indexOf(selectedComponent);
-          SourceStructureExplorerItem source = selectedComponent.getSourceStructureExplorerItem();
-          switch (event.getNativeKeyCode()) {
-            case KeyCodes.KEY_DOWN:
-              if (posInParent < siblings.size() - 1) {
-                MockComponent next = siblings.get(posInParent + 1);
-                source.moveTo(next.getSourceStructureExplorerItem(), 1);
-              } else if (!parent.isRoot()) {
-                source.moveTo(parent.getSourceStructureExplorerItem(), 1);
-              }
-              break;
-            case KeyCodes.KEY_UP:
-              if (posInParent > 0) {
-                MockComponent prev = siblings.get(posInParent - 1);
-                source.moveTo(prev.getSourceStructureExplorerItem(), -1);
-              } else if (!parent.isRoot()) {
-                source.moveTo(parent.getSourceStructureExplorerItem(), -1);
-              }
-              break;
-            default:
-              break;
-          }
-        }
-      }
-    } else if (event.getNativeKeyCode() == KeyCodes.KEY_P && !palettePanel.shouldSuppressShortcuts()) {
-      designProperties.focusFirstCategory();
-    } else if (event.getNativeKeyCode() == KeyCodes.KEY_M && !palettePanel.shouldSuppressShortcuts()) {
-      AssetListBox.getAssetListBox().getAssetList().getTree().setFocus(true);
-    }
   }
 
   /*

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleVisibleComponentsPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleVisibleComponentsPanel.java
@@ -102,4 +102,6 @@ public abstract class SimpleVisibleComponentsPanel<T extends DesignerRootCompone
   public void onResetDatabase() {
 
   }
+
+  public abstract void focusCheckbox();
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
@@ -19,6 +19,7 @@ import com.google.appinventor.shared.simple.ComponentDatabaseChangeListener;
 import com.google.appinventor.shared.simple.ComponentDatabaseInterface;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -84,6 +85,7 @@ public abstract class AbstractPalettePanel<
 
   private final TextBox searchText;
   private final FlowPanel searchResults;
+  private Element previousFocus;
   private JsArrayString arrayString = (JsArrayString) JsArrayString.createArray();
   private String lastSearch = "";
   private Map<String, SimplePaletteItem> searchSimplePaletteItems = new HashMap<String, SimplePaletteItem>();
@@ -183,6 +185,7 @@ public abstract class AbstractPalettePanel<
                 && !shouldSuppressShortcuts() && !event.isAltKeyDown()) {
           {
             event.preventDefault();
+            previousFocus = getActiveElement();
             searchText.setFocus(true);
           }
         }
@@ -256,8 +259,17 @@ public abstract class AbstractPalettePanel<
     @Override
     public void onKeyDown(KeyDownEvent event) {
       if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE) {
+        event.preventDefault();
+        event.stopPropagation();
         searchResults.clear();
         searchText.setText("");
+        lastSearch = "";
+        doSearch();
+        if (previousFocus != null && canReceiveFocus(previousFocus)) {
+          previousFocus.focus();
+        } else {
+          searchText.getElement().blur();
+        }
       }
     }
   }
@@ -545,6 +557,14 @@ public abstract class AbstractPalettePanel<
   public boolean shouldSuppressShortcuts() {
     return isTextboxFocused() || isMenuOpen();
   }
+
+  private native boolean canReceiveFocus(Element el)/*-{
+    return $doc.body.contains(el) && el.offsetParent != null;
+  }-*/;
+
+  private native Element getActiveElement()/*-{
+    return $doc.activeElement;
+  }-*/;
 
   private void requestRebuildList() {
     if (rebuild != null) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
@@ -6,12 +6,10 @@
 
 package com.google.appinventor.client.editor.simple.palette;
 
-import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.editor.designer.DesignerEditor;
 import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.editor.simple.components.i18n.ComponentTranslationTable;
 import com.google.appinventor.client.editor.simple.components.utils.PropertiesUtil;
-import com.google.appinventor.client.editor.youngandroid.DesignToolbar;
 import com.google.appinventor.client.json.JsArray;
 import com.google.appinventor.common.version.AppInventorFeatures;
 import com.google.appinventor.components.common.ComponentCategory;
@@ -33,7 +31,6 @@ import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -175,22 +172,6 @@ public abstract class AbstractPalettePanel<
         doSearch();
       }
     });
-
-    /* User presses the slash key, the search text box is focused */
-    RootPanel.get().addDomHandler(new KeyDownHandler() {
-      @Override
-      public void onKeyDown(KeyDownEvent event) {
-        DesignToolbar designToolbar = Ode.getInstance().getDesignToolbar();
-        if (designToolbar.currentView == DesignToolbar.View.DESIGNER && event.getNativeKeyCode() == 191
-                && !shouldSuppressShortcuts() && !event.isAltKeyDown()) {
-          {
-            event.preventDefault();
-            previousFocus = getActiveElement();
-            searchText.setFocus(true);
-          }
-        }
-      }
-    }, KeyDownEvent.getType());
 
     panel.add(searchText);
     panel.setWidth("100%");
@@ -556,6 +537,12 @@ public abstract class AbstractPalettePanel<
 
   public boolean shouldSuppressShortcuts() {
     return isTextboxFocused() || isMenuOpen();
+  }
+
+  @Override
+  public void focusSearchBox() {
+    previousFocus = getActiveElement();
+    searchText.setFocus(true);
   }
 
   private native boolean canReceiveFocus(Element el)/*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePalettePanel.java
@@ -48,4 +48,6 @@ public interface SimplePalettePanel {
   boolean isMenuOpen();
 
   boolean shouldSuppressShortcuts();
+
+  void focusSearchBox();
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -516,18 +516,4 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     }
     return result;
   }
-
-  @Override
-  public void onKeyDown(KeyDownEvent event) {
-    if (!isActiveEditor()) {
-      return;  // Not the active editor
-    }
-    if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.shouldSuppressShortcuts()
-        && !(event.isControlKeyDown() || event.isMetaKeyDown())) {
-      getVisibleComponentsPanel().focusCheckbox();
-    } else {
-      super.onKeyDown(event);
-    }
-  }
-
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
@@ -18,9 +18,9 @@ import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetsFolder;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
 
-import com.google.gwt.core.client.GWT;
+import com.google.appinventor.shared.storage.StorageUtil;
 
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.core.client.GWT;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -29,6 +29,8 @@ import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
+
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -44,7 +46,9 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The "Click to Add/Delete Data" dialog for the ListView ListData property.
@@ -67,7 +71,6 @@ public class ListViewAddDataDialog {
       GWT.create(ListViewAddDataDialogUiBinder.class);
 
   @UiField Dialog dialogBox;
-  @UiField HorizontalPanel headerRow;
   @UiField FlowPanel rowsContainer;
   @UiField Button addRow;
   @UiField Button save;
@@ -82,28 +85,51 @@ public class ListViewAddDataDialog {
   private final boolean showDetail;
   private final boolean showImage;
 
-  /* Asset names (incl. "None") used to populate each row's image picker. */
+  /* Asset names (incl. "None") offered by each row's image picker. */
   private final List<String> imageChoices;
+
+  /* Map from asset name to a previewable URL (no entry for "None"). */
+  private final Map<String, String> imageUrls;
 
   ListViewAddDataDialog(YoungAndroidListViewAddDataPropertyEditor owner, int layout) {
     this.owner = owner;
     this.layout = layout;
     this.showDetail = layoutHasDetail(layout);
     this.showImage = layoutHasImage(layout);
-    this.imageChoices = buildImageChoices();
+    this.imageUrls = new HashMap<String, String>();
+    this.imageChoices = buildImageChoices(imageUrls);
     UI_BINDER.createAndBindUi(this);
 
-    dialogBox.setCaption(MESSAGES.listDataAddDataTitle());
     dialogBox.setAriaLabel(MESSAGES.listDataAddDataTitle());
     addRow.setText(MESSAGES.listDataAddRowButton());
     save.setText(MESSAGES.saveButton());
     cancel.setText(MESSAGES.cancelButton());
 
-    buildHeader();
-
     for (JSONObject item : owner.getItems()) {
-      rowsContainer.add(new ListViewDataRow(item, showDetail, showImage, imageChoices));
+      rowsContainer.add(newRow(item));
     }
+    updateCount();
+  }
+
+  /** Creates a data row wired to refresh the item count when it deletes itself. */
+  private ListViewDataRow newRow(JSONObject item) {
+    return new ListViewDataRow(item, showDetail, showImage, imageChoices, imageUrls,
+        new Runnable() {
+          @Override
+          public void run() {
+            updateCount();
+          }
+        });
+  }
+
+  /** Renders the title plus the live item count into the draggable caption bar. */
+  private void updateCount() {
+    String html = "<span class=\"lie-cap-title\">"
+        + SafeHtmlUtils.htmlEscape(MESSAGES.listDataAddDataTitle())
+        + "</span><span class=\"lie-cap-count\">"
+        + SafeHtmlUtils.htmlEscape(MESSAGES.listDataItemCount(rowsContainer.getWidgetCount()))
+        + "</span>";
+    dialogBox.getCaption().setHTML(SafeHtmlUtils.fromTrustedString(html));
   }
 
   /** Centers and shows the dialog. */
@@ -126,8 +152,11 @@ public class ListViewAddDataDialog {
         || layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT;
   }
 
-  /** Builds the list of selectable image assets ("None" plus every project asset). */
-  private List<String> buildImageChoices() {
+  /**
+   * Builds the list of selectable image assets ("None" plus every project asset) and fills
+   * {@code urls} with a previewable URL per asset name.
+   */
+  private List<String> buildImageChoices(Map<String, String> urls) {
     Project project = Ode.getInstance().getProjectManager()
         .getProject(owner.getSimpleEditor().getProjectId());
     YoungAndroidAssetsFolder assetsFolder =
@@ -137,34 +166,10 @@ public class ListViewAddDataDialog {
     if (assetsFolder != null) {
       for (ProjectNode node : assetsFolder.getChildren()) {
         choices.add(node.getName());
+        urls.put(node.getName(), StorageUtil.getFileUrl(node.getProjectId(), node.getFileId()));
       }
     }
     return choices;
-  }
-
-  /** Adds the column headers that match the visible fields for the current layout. */
-  private void buildHeader() {
-    headerRow.add(makeHeaderLabel(MESSAGES.listDataMainTextHeader(), ListViewDataRow.COLUMN_TEXT_WIDTH));
-    if (showDetail) {
-      headerRow.add(
-          makeHeaderLabel(MESSAGES.listDataDetailTextHeader(), ListViewDataRow.COLUMN_TEXT_WIDTH));
-    }
-    if (showImage) {
-      headerRow.add(makeHeaderLabel(MESSAGES.listDataImageHeader(), ListViewDataRow.COLUMN_IMAGE_WIDTH));
-    }
-  }
-
-  /** Creates a header label whose width matches the row field below it so the columns line up. */
-  private static Label makeHeaderLabel(String text, String width) {
-    Label label = new Label(text);
-    label.setWidth(width);
-    // Match the row field's box model so the header lines up: border-box width, no extra left
-    // padding from the dialog stylesheet, and the same right margin the fields use as the gap.
-    Style style = label.getElement().getStyle();
-    style.setProperty("boxSizing", "border-box");
-    style.setPaddingLeft(0, Style.Unit.PX);
-    style.setMarginRight(8, Style.Unit.PX);
-    return label;
   }
 
   @UiHandler("addRow")
@@ -178,7 +183,8 @@ public class ListViewAddDataDialog {
     if (showImage) {
       data.put("Image", new JSONString("None"));
     }
-    rowsContainer.add(new ListViewDataRow(data, showDetail, showImage, imageChoices));
+    rowsContainer.add(newRow(data));
+    updateCount();
   }
 
   @UiHandler("save")
@@ -232,7 +238,7 @@ public class ListViewAddDataDialog {
    */
   @UiHandler("topInvisible")
   void focusLast(FocusEvent event) {
-    cancel.setFocus(true);
+    save.setFocus(true);
   }
 
   @UiHandler("bottomInvisible")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
@@ -6,21 +6,24 @@
     xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:wiz="urn:import:com.google.appinventor.client.wizards">
 
+  <!-- The standard (draggable) caption bar is kept as the header; "lie-dialog" only lets Ya.css
+       right-align the item count inside it. -->
   <wiz:Dialog ui:field="dialogBox" role="dialog" ariaModal="true"
-              styleName="ode-DialogBox">
-    <g:VerticalPanel>
+              styleName="ode-DialogBox" addStyleNames="lie-dialog">
+    <g:FlowPanel>
       <g:Button ui:field="topInvisible" styleName="FocusTrap" tabIndex="-1"/>
 
-      <g:HorizontalPanel ui:field="headerRow"/>
-      <g:FlowPanel ui:field="rowsContainer"/>
-      <g:Button ui:field="addRow"/>
+      <g:FlowPanel styleName="lie-body">
+        <g:FlowPanel ui:field="rowsContainer"/>
+        <g:Button ui:field="addRow" styleName="lie-add"/>
+      </g:FlowPanel>
 
-      <g:HorizontalPanel horizontalAlignment="ALIGN_CENTER">
-        <g:Button ui:field="save"/>
-        <g:Button ui:field="cancel"/>
-      </g:HorizontalPanel>
+      <g:FlowPanel styleName="lie-foot">
+        <g:Button ui:field="cancel" styleName="lie-btn" addStyleNames="lie-btn-ghost"/>
+        <g:Button ui:field="save" styleName="lie-btn" addStyleNames="lie-btn-primary"/>
+      </g:FlowPanel>
 
       <g:Button ui:field="bottomInvisible" styleName="FocusTrap" tabIndex="-1"/>
-    </g:VerticalPanel>
+    </g:FlowPanel>
   </wiz:Dialog>
 </ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
@@ -9,9 +9,11 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.gwt.core.client.GWT;
 
-import com.google.gwt.dom.client.Style.Unit;
-
 import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
 
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
@@ -23,20 +25,25 @@ import com.google.gwt.uibinder.client.UiHandler;
 
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.FocusPanel;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.InlineLabel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.TextBox;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A single editable row in the ListView ListData editor dialog.
  *
- * <p>Replaces the virtualized {@code CellTable} cells with real, focusable widgets (a
- * {@link TextBox} for the main text, an optional {@link TextBox} for the detail text, an optional
- * {@link ListBox} for the image and a delete {@link Button}). The detail and image widgets are
- * shown or hidden according to the current ListView layout, mirroring the per-layout column logic
- * the {@code CellTable} used to perform.
+ * <p>Each row is a "thumbnail-forward" card built from real, focusable widgets: an image thumbnail
+ * (which opens an asset picker when clicked), a {@link TextBox} for the main text, an optional
+ * {@link TextBox} for the detail text and a delete {@link Button}. The detail and image widgets are
+ * shown or hidden according to the current ListView layout, mirroring the per-layout column logic the
+ * old {@code CellTable} performed.
  *
  * <p>The row owns its backing {@link JSONObject}: {@link #toJsonObject()} writes the current widget
  * values back into it and returns it, preserving any keys that belong to other layouts so the saved
@@ -44,47 +51,54 @@ import java.util.List;
  */
 public class ListViewDataRow extends Composite {
 
-  interface ListViewDataRowUiBinder extends UiBinder<HorizontalPanel, ListViewDataRow> {}
+  interface ListViewDataRowUiBinder extends UiBinder<FlowPanel, ListViewDataRow> {}
 
   private static final ListViewDataRowUiBinder UI_BINDER =
       GWT.create(ListViewDataRowUiBinder.class);
 
-  // Column widths, shared with the dialog header (ListViewAddDataDialog) so the header labels line
-  // up with the fields below them. Combined with box-sizing: border-box on the fields, the rendered
-  // widths match these values exactly.
-  static final String COLUMN_TEXT_WIDTH = "150px";
-  static final String COLUMN_IMAGE_WIDTH = "130px";
+  /** Sentinel value used by the ListData JSON for "no image". */
+  private static final String NO_IMAGE = "None";
 
+  @UiField FlowPanel container;
+  @UiField FlowPanel thumbColumn;
+  @UiField FocusPanel thumbTile;
+  @UiField Label thumbName;
   @UiField TextBox mainText;
   @UiField TextBox detailText;
-  @UiField ListBox imagePicker;
   @UiField Button delete;
 
   private final JSONObject item;
   private final boolean showDetail;
   private final boolean showImage;
+  private final List<String> imageChoices;
+  private final Map<String, String> imageUrls;
+  private final Runnable onDelete;
+
+  /** The currently selected image asset name (or {@link #NO_IMAGE}). */
+  private String selectedImage = NO_IMAGE;
 
   /**
    * @param item the backing data for this row (mutated in place by {@link #toJsonObject()})
    * @param showDetail whether the detail text field applies to the current layout
    * @param showImage whether the image picker applies to the current layout
-   * @param imageChoices the asset names (including "None") to populate the image picker with
+   * @param imageChoices the asset names (including "None") offered by the picker
+   * @param imageUrls map from asset name to a previewable URL (no entry for "None")
+   * @param onDelete callback invoked after this row removes itself (lets the dialog update its count)
    */
   ListViewDataRow(JSONObject item, boolean showDetail, boolean showImage,
-      List<String> imageChoices) {
+      List<String> imageChoices, Map<String, String> imageUrls, Runnable onDelete) {
     this.item = item;
     this.showDetail = showDetail;
     this.showImage = showImage;
+    this.imageChoices = imageChoices;
+    this.imageUrls = imageUrls;
+    this.onDelete = onDelete;
     initWidget(UI_BINDER.createAndBindUi(this));
 
-    mainText.setWidth(COLUMN_TEXT_WIDTH);
-    detailText.setWidth(COLUMN_TEXT_WIDTH);
-    imagePicker.setWidth(COLUMN_IMAGE_WIDTH);
-
-    delete.setText(MESSAGES.deleteButton());
-    // The dialog stylesheet puts a 10px margin on every button; remove it for the in-row delete
-    // button so the rows stay compact.
-    delete.getElement().getStyle().setMargin(0, Unit.PX);
+    delete.setText("×");  // multiplication sign, used as a compact close/delete glyph
+    // Keep the visible glyph short but expose the real action name to assistive tech.
+    delete.getElement().setAttribute("aria-label", MESSAGES.deleteButton());
+    delete.setTitle(MESSAGES.deleteButton());
 
     mainText.setText(getString("Text1"));
 
@@ -95,12 +109,28 @@ public class ListViewDataRow extends Composite {
     }
 
     if (showImage) {
-      for (String choice : imageChoices) {
-        imagePicker.addItem(choice);
-      }
-      selectImage(getString("Image"));
+      selectedImage = normalizeImage(getString("Image"));
+      updateThumbnail();
+      thumbTile.getElement().setTabIndex(0);
+      thumbTile.getElement().setAttribute("aria-label", MESSAGES.listDataImageHeader());
+      thumbTile.addClickHandler(new ClickHandler() {
+        @Override
+        public void onClick(ClickEvent event) {
+          openImagePicker();
+        }
+      });
+      thumbTile.addKeyDownHandler(new KeyDownHandler() {
+        @Override
+        public void onKeyDown(KeyDownEvent event) {
+          int key = event.getNativeKeyCode();
+          if (key == KeyCodes.KEY_ENTER || key == KeyCodes.KEY_SPACE) {
+            event.preventDefault();
+            openImagePicker();
+          }
+        }
+      });
     } else {
-      imagePicker.setVisible(false);
+      thumbColumn.setVisible(false);
     }
   }
 
@@ -111,9 +141,7 @@ public class ListViewDataRow extends Composite {
       item.put("Text2", new JSONString(detailText.getText()));
     }
     if (showImage) {
-      int selected = imagePicker.getSelectedIndex();
-      String image = selected >= 0 ? imagePicker.getItemText(selected) : "None";
-      item.put("Image", new JSONString(image));
+      item.put("Image", new JSONString(selectedImage));
     }
     return item;
   }
@@ -130,19 +158,114 @@ public class ListViewDataRow extends Composite {
     return "";
   }
 
-  /** Selects the image-picker entry matching {@code value}, falling back to the first ("None"). */
-  private void selectImage(String value) {
-    for (int i = 0; i < imagePicker.getItemCount(); i++) {
-      if (imagePicker.getItemText(i).equals(value)) {
-        imagePicker.setSelectedIndex(i);
-        return;
-      }
+  /** Maps a stored image value to a valid choice, falling back to "None". */
+  private String normalizeImage(String value) {
+    return imageChoices.contains(value) ? value : NO_IMAGE;
+  }
+
+  /** Renders the thumbnail tile and filename label for the current selection. */
+  private void updateThumbnail() {
+    String url = imageUrls.get(selectedImage);
+    if (url != null) {
+      Image image = new Image(url);
+      thumbTile.setWidget(image);
+      thumbTile.addStyleName("lie-thumb-filled");
+      thumbName.setText(selectedImage);
+      thumbName.setTitle(selectedImage);
+    } else {
+      thumbTile.setWidget(new InlineLabel("IMG"));
+      thumbTile.removeStyleName("lie-thumb-filled");
+      thumbName.setText(NO_IMAGE);
+      thumbName.setTitle(NO_IMAGE);
     }
-    imagePicker.setSelectedIndex(0);
+  }
+
+  /** Opens the asset picker anchored to the thumbnail tile. */
+  private void openImagePicker() {
+    AssetImagePicker picker = new AssetImagePicker(imageChoices, imageUrls, selectedImage,
+        new AssetImagePicker.Callback() {
+          @Override
+          public void onImageSelected(String name) {
+            selectedImage = name;
+            updateThumbnail();
+          }
+        });
+    picker.showRelativeTo(thumbTile);
   }
 
   @UiHandler("delete")
-  void onDelete(ClickEvent event) {
+  void onDeleteClicked(ClickEvent event) {
     removeFromParent();
+    if (onDelete != null) {
+      onDelete.run();
+    }
+  }
+
+  /**
+   * A small popup that lists "None" plus every project image asset (with a preview swatch) and
+   * reports the chosen asset name back through {@link Callback}. This realizes Susan's preferred
+   * interaction: clicking the row thumbnail opens this picker rather than using a dropdown.
+   */
+  static class AssetImagePicker extends PopupPanel {
+
+    interface Callback {
+      void onImageSelected(String name);
+    }
+
+    AssetImagePicker(List<String> choices, Map<String, String> urls, String current,
+        final Callback callback) {
+      super(true, false);  // autoHide, non-modal
+      setAnimationEnabled(true);
+
+      FlowPanel list = new FlowPanel();
+      list.setStyleName("lie-picker");
+
+      for (final String name : choices) {
+        FocusPanel item = new FocusPanel();
+        item.setStyleName("lie-picker-item");
+        if (name.equals(current)) {
+          item.addStyleName("lie-picker-selected");
+        }
+        item.getElement().setTabIndex(0);
+
+        FlowPanel row = new FlowPanel();
+        row.setStyleName("lie-picker-itemrow");
+
+        FlowPanel swatch = new FlowPanel();
+        swatch.setStyleName("lie-picker-swatch");
+        String url = urls.get(name);
+        if (url != null) {
+          swatch.add(new Image(url));
+        }
+        row.add(swatch);
+
+        Label nameLabel = new Label(name);
+        nameLabel.setStyleName("lie-picker-name");
+        row.add(nameLabel);
+
+        item.setWidget(row);
+        item.addClickHandler(new ClickHandler() {
+          @Override
+          public void onClick(ClickEvent event) {
+            callback.onImageSelected(name);
+            hide();
+          }
+        });
+        item.addKeyDownHandler(new KeyDownHandler() {
+          @Override
+          public void onKeyDown(KeyDownEvent event) {
+            int key = event.getNativeKeyCode();
+            if (key == KeyCodes.KEY_ENTER || key == KeyCodes.KEY_SPACE) {
+              event.preventDefault();
+              callback.onImageSelected(name);
+              hide();
+            }
+          }
+        });
+        list.add(item);
+      }
+
+      setWidget(list);
+    }
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.ui.xml
@@ -5,23 +5,20 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:g="urn:import:com.google.gwt.user.client.ui">
 
-  <ui:style>
-    .row {
-      padding: 2px 0;
-    }
-    /* border-box so a field's rendered width equals the width set in Java, which is the same value
-       the dialog uses for the matching header label, keeping the header and columns aligned. */
-    .field {
-      box-sizing: border-box;
-      margin-right: 8px;
-    }
-  </ui:style>
+  <!-- Styling lives in war/static/css/Ya.css (the .lie-* classes) so it is
+       shared with the Java-built image picker popup. -->
+  <g:FlowPanel ui:field="container" styleName="lie-row">
 
-  <g:HorizontalPanel ui:field="container" styleName="{style.row}"
-      verticalAlignment="ALIGN_MIDDLE">
-    <g:TextBox ui:field="mainText" addStyleNames="{style.field}"/>
-    <g:TextBox ui:field="detailText" addStyleNames="{style.field}"/>
-    <g:ListBox ui:field="imagePicker" addStyleNames="{style.field}"/>
-    <g:Button ui:field="delete"/>
-  </g:HorizontalPanel>
+    <g:FlowPanel ui:field="thumbColumn" styleName="lie-thumb">
+      <g:FocusPanel ui:field="thumbTile" styleName="lie-thumb-tile"/>
+      <g:Label ui:field="thumbName" styleName="lie-thumb-name"/>
+    </g:FlowPanel>
+
+    <g:FlowPanel styleName="lie-fields">
+      <g:TextBox ui:field="mainText" styleName="lie-input" addStyleNames="lie-input-main"/>
+      <g:TextBox ui:field="detailText" styleName="lie-input" addStyleNames="lie-input-detail"/>
+    </g:FlowPanel>
+
+    <g:Button ui:field="delete" styleName="lie-del"/>
+  </g:FlowPanel>
 </ui:UiBinder>

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -3655,3 +3655,257 @@ div.dropdiv p {
   color: red;
   font-weight: bolder;
 }
+
+/* ===================================================================
+   ListView "List Item Editor" (ListData property editor) redesign.
+   "Thumbnail-Forward" direction. Plain CSS so it works for both the
+   UiBinder widgets and the Java-built image-picker popup. The accessible
+   dialog chrome (ARIA/Esc/focus) is provided by wizards/Dialog and is
+   left untouched -- only the visible caption bar is hidden so the custom
+   header below can take its place (the accessible name still comes from
+   the dialog's aria-label).
+   =================================================================== */
+
+/* Center the title in the standard (draggable) caption bar; the count sits to its right. */
+.ode-DialogBox.lie-dialog .Caption {
+  display: flex;
+  align-items: center;
+}
+.lie-cap-title {
+  flex: 1;
+  text-align: center;
+}
+.lie-cap-count {
+  flex-shrink: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  font-weight: 400;
+  opacity: .75;
+}
+
+/* ---- Body / rows ------------------------------------------------- */
+.lie-body {
+  padding: 8px 16px 12px;
+}
+.lie-row {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 11px 0;
+  border-top: 1px solid #f0f0f0;
+}
+.lie-row:first-child {
+  border-top: none;
+}
+
+/* Image cell -- the signature of this direction */
+.lie-thumb {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 64px;
+}
+.lie-thumb-tile {
+  width: 56px;
+  height: 56px;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  background: repeating-linear-gradient(45deg, #efefef, #efefef 4px, #f7f7f7 4px, #f7f7f7 8px);
+  color: #b4b4b4;
+  font: 500 9px 'Roboto Mono', monospace;
+  text-align: center;
+  line-height: 56px;
+  cursor: pointer;
+  outline: none;
+  overflow: hidden;
+}
+.lie-thumb-tile:hover {
+  border-color: #70b3d8;
+}
+.lie-thumb-tile:focus {
+  border-color: #70b3d8;
+  box-shadow: 0 0 0 2px #d6e9f8;
+}
+/* When an image is chosen the tile shows the asset, not the placeholder pattern. */
+.lie-thumb-tile.lie-thumb-filled {
+  background: #ffffff;
+  line-height: 0;
+}
+.lie-thumb-tile img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.lie-thumb-name {
+  margin-top: 4px;
+  max-width: 60px;
+  font: 400 9px 'Roboto Mono', monospace;
+  color: #9a9a9a;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Text fields */
+.lie-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+.lie-input {
+  width: 100%;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #333333;
+  outline: none;
+}
+.lie-input-main {
+  height: 34px;
+  padding: 0 11px;
+  border: 1px solid #d6d6d6;
+  font: 500 14px 'Roboto', sans-serif;
+}
+.lie-input-detail {
+  height: 30px;
+  padding: 0 11px;
+  border: 1px solid #e2e2e2;
+  background: #fafafa;
+  color: #777777;
+  font: 400 12px 'Roboto', sans-serif;
+}
+.lie-input:focus {
+  border-color: #70b3d8;
+  box-shadow: 0 0 0 2px #d6e9f8;
+}
+.lie-input-detail:focus {
+  background: #ffffff;
+}
+
+/* Delete control -- neutral until hovered, then (and only then) red */
+.lie-del {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: none;
+  color: #c4c4c4;
+  font-size: 18px;
+  line-height: 1;
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+}
+.lie-del:hover {
+  color: #d9534f;
+  background: #fbe9e9;
+}
+
+/* ---- Add row ----------------------------------------------------- */
+.lie-add {
+  width: 100%;
+  margin-top: 8px;
+  padding: 10px;
+  border: 1.5px dashed #c4c4c4;
+  background: none;
+  color: #777777;
+  font: 500 13px 'Roboto', sans-serif;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.lie-add:hover {
+  border-color: #a5cf47;
+  color: #6f9e1f;
+  background: #fbfdf5;
+}
+
+/* ---- Footer ------------------------------------------------------ */
+.lie-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 13px 18px;
+  border-top: 1px solid #eee;
+  background: #fafafa;
+}
+.lie-btn {
+  border: none;
+  border-radius: 4px;
+  font: 500 13px 'Roboto', sans-serif;
+  cursor: pointer;
+  margin: 0;
+}
+.lie-btn-ghost {
+  padding: 8px 16px;
+  background: none;
+  color: #888888;
+}
+.lie-btn-ghost:hover {
+  background: #ededed;
+  color: #555555;
+}
+.lie-btn-primary {
+  padding: 8px 22px;
+  background: #a5cf47;
+  color: #33401a;
+}
+.lie-btn-primary:hover {
+  background: #98c23a;
+}
+
+/* ---- Image picker popup (Susan's click-the-thumbnail option) ------ */
+.lie-picker {
+  max-height: 280px;
+  overflow-y: auto;
+  background: #ffffff;
+  border: 1px solid #d2d2d2;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  padding: 4px;
+}
+.lie-picker-item {
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  outline: none;
+}
+.lie-picker-item:hover,
+.lie-picker-item:focus {
+  background: #d6e9f8;
+}
+.lie-picker-item.lie-picker-selected {
+  background: #eef2e0;
+}
+/* The focusable item holds a single child, so the row layout sits here. */
+.lie-picker-itemrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.lie-picker-swatch {
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  border: 1px solid #e0e0e0;
+  background: repeating-linear-gradient(45deg, #efefef, #efefef 4px, #f7f7f7 4px, #f7f7f7 8px);
+  overflow: hidden;
+  flex-shrink: 0;
+  line-height: 0;
+}
+.lie-picker-swatch img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.lie-picker-name {
+  font: 400 13px 'Roboto', sans-serif;
+  color: #333333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Migrates all of the designer related shortcuts to the ShortcutRegistry, except the alt+up/down keys to move components up and down the tree.