### PR TITLE
Wire shortcuts from registry storage when needed

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1021,6 +1021,7 @@ public class Ode implements EntryPoint {
    * Initializes all UI elements.
    */
   private Promise<Object> initializeUi(Object result) {
+    ShortcutRegistry.getInstance().applyKeyOverrides(ShortcutRegistry.getInstance().loadKeyOverrides());
     RootPanel.get().addDomHandler(new KeyDownHandler() {
       @Override
       public void onKeyDown(KeyDownEvent keyDownEvent) {

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -780,6 +780,14 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Placeholder shown in the key column while waiting for the user to press a key")
   String shortcutsPressKey();
 
+  @DefaultMessage("Already used by {0}")
+  @Description("Shown when the user presses a key combo already bound to another shortcut")
+  String shortcutKeyConflict(String otherDisplayName);
+
+  @DefaultMessage("Already used by another shortcut")
+  @Description("Shown when the user presses a key combo already bound to another shortcut whose name isn't shown in this dialog")
+  String shortcutKeyConflictGeneric();
+
   @DefaultMessage("Focus Component search box")
   @Description("Keyboard shortcut action: move focus to the component search box")
   String shortcutFocusSearch();

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/ShowShortcutsAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/ShowShortcutsAction.java
@@ -55,10 +55,11 @@ public class ShowShortcutsAction implements Command {
     SHORTCUTS.add(new ShortcutDef("focus_properties",    MESSAGES.shortcutFocusProperties(),     "Alt+80",           true));
     SHORTCUTS.add(new ShortcutDef("focus_media",         MESSAGES.shortcutFocusMedia(),          "Alt+77",           true));
     SHORTCUTS.add(new ShortcutDef("toggle_view",         MESSAGES.shortcutToggleView(),          "Control+Alt",      false));
-    SHORTCUTS.add(new ShortcutDef("rename_component",    MESSAGES.shortcutRenameComponent(),     "Alt+78",           true));
+    // Not yet wired into ShortcutRegistry (see plan follow-up) — remapping them currently has no effect.
+    SHORTCUTS.add(new ShortcutDef("rename_component",    MESSAGES.shortcutRenameComponent(),     "Alt+78",           false));
     SHORTCUTS.add(new ShortcutDef("delete_component",    MESSAGES.shortcutDeleteComponent(),     "Delete/Backspace", false));
-    SHORTCUTS.add(new ShortcutDef("reset_connection",    MESSAGES.shortcutResetConnection(),     "Alt+Shift+82",     true));
-    SHORTCUTS.add(new ShortcutDef("refresh_companion",   MESSAGES.shortcutRefreshCompanion(),    "Alt+82",           true));
+    SHORTCUTS.add(new ShortcutDef("reset_connection",    MESSAGES.shortcutResetConnection(),     "Alt+Shift+82",     false));
+    SHORTCUTS.add(new ShortcutDef("refresh_companion",   MESSAGES.shortcutRefreshCompanion(),    "Alt+82",           false));
     SHORTCUTS.add(new ShortcutDef("navigate_components", MESSAGES.shortcutNavigateComponents(),  "↑/↓",              false));
     SHORTCUTS.add(new ShortcutDef("show_shortcuts",      MESSAGES.shortcutOpenDialog(),          "Alt+Shift+191",    false));
   }
@@ -235,6 +236,7 @@ public class ShowShortcutsAction implements Command {
     label.removeStyleName("ode-shortcut-capturing");
     label.removeStyleName("ode-shortcut-editable");
     label.removeStyleName("ode-shortcut-locked");
+    label.removeStyleName("ode-shortcut-conflict");
     if (s == activeCapture) {
       label.setText(MESSAGES.shortcutsPressKey());
       label.addStyleName("ode-shortcut-capturing");
@@ -273,13 +275,40 @@ public class ShowShortcutsAction implements Command {
         }
 
         event.cancel();
-        s.currentKey = buildSerializedKey(nativeEvent);
+        String candidateKey = buildSerializedKey(nativeEvent);
+        String conflictingActionId = ShortcutRegistry.getInstance().findConflict(s.actionId, candidateKey);
+        if (conflictingActionId != null) {
+          showConflict(s, row, conflictingActionId);
+          return;
+        }
+        s.currentKey = candidateKey;
         activeCapture = null;
         cancelCapture();
         updateKeyCell(s, row);
         resetButton.setEnabled(hasOverrides());
       }
     });
+  }
+
+  // Shows an inline "already used by X" message on the row without committing
+  // the captured key; capture stays active so the user can try another combo.
+  private void showConflict(ShortcutDef s, int row, String conflictingActionId) {
+    String otherName = findDisplayName(conflictingActionId);
+    Label label = keyLabels[row - 1];
+    label.setText(otherName != null
+        ? MESSAGES.shortcutKeyConflict(otherName)
+        : MESSAGES.shortcutKeyConflictGeneric());
+    label.removeStyleName("ode-shortcut-capturing");
+    label.addStyleName("ode-shortcut-conflict");
+  }
+
+  private static String findDisplayName(String actionId) {
+    for (ShortcutDef s : SHORTCUTS) {
+      if (s.actionId.equals(actionId)) {
+        return s.displayName;
+      }
+    }
+    return null;
   }
 
   private void cancelCapture() {
@@ -317,6 +346,7 @@ public class ShowShortcutsAction implements Command {
       }
     }
     ShortcutRegistry.getInstance().saveKeyOverrides(overrides);
+    ShortcutRegistry.getInstance().applyKeyOverrides(overrides);
   }
 
   // Converts a Blockly-style serialized key string to a human-readable label.

--- a/appinventor/appengine/src/com/google/appinventor/client/style/classic/variableColors.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/classic/variableColors.css
@@ -791,6 +791,10 @@ path.ode-SimpleMockMapFeature-selected {
   color: gray-800;
 }
 
+.ode-DialogBox .ode-shortcut-conflict {
+  color: v-red;
+}
+
 .ode-DialogBox .gwt-Tree {
   border: thin solid gray-300;
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -1417,6 +1417,10 @@ path.ode-SimpleMockMapFeature-selected {
   color: gray-700;
 }
 
+.ode-DialogBox .ode-shortcut-conflict {
+  color: v-red;
+}
+
 .ode-FormCheckboxLabel {
   display: inline-block;
   margin: 10px;

--- a/appinventor/appengine/src/com/google/appinventor/client/utils/ShortcutRegistry.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/ShortcutRegistry.java
@@ -80,18 +80,114 @@ public class ShortcutRegistry {
   private static final ShortcutRegistry instance = new ShortcutRegistry();
   private final Map<Class<?>, Map<String, Function<?, Boolean>>> registry =  new HashMap<Class<?>, Map<String, Function<?, Boolean>>>();
 
+  // Bookkeeping only, never consulted by onKeyDown: lets a later remap find and
+  // move an already-registered shortcut's entry in `registry` without changing
+  // that map's shape or dispatch lookup.
+  private static final class RegisteredShortcut<T> {
+    final String actionId;
+    final Class<T> viewClass;
+    final String defaultKey;
+    final Function<T, Boolean> callback;
+    String currentKey;
+
+    RegisteredShortcut(String actionId, Class<T> viewClass, String defaultKey, Function<T, Boolean> callback) {
+      this.actionId = actionId;
+      this.viewClass = viewClass;
+      this.defaultKey = defaultKey;
+      this.callback = callback;
+      this.currentKey = defaultKey;
+    }
+  }
+
+  private final Map<String, RegisteredShortcut<?>> byActionId = new HashMap<String, RegisteredShortcut<?>>();
+  private Map<String, String> overrides = new HashMap<String, String>();
+
   public static ShortcutRegistry getInstance() {
     return instance;
   }
 
   public <T extends Widget> void registerViewShortcut(Class<T> viewClass, String name, String displayName, int keyCode,
       int[] modifiers, Function<T, Boolean> callback) {
+    registerWithDefaultKey(viewClass, name, createSerializedKey(keyCode, modifiers), callback);
+  }
+
+  /**
+   * Registers a shortcut with an already-serialized default key, bypassing the
+   * JSNI-only {@link #createSerializedKey}. Package-visible for unit tests,
+   * which run as plain JVM tests with no {@code $wnd.Blockly} available.
+   */
+  <T extends Widget> void registerWithDefaultKey(Class<T> viewClass, String name, String defaultKey,
+      Function<T, Boolean> callback) {
     Map<String, Function<?, Boolean>> viewShortcuts = registry.get(viewClass);
     if (viewShortcuts == null) {
       viewShortcuts = new HashMap<String, Function<?, Boolean>>();
       registry.put(viewClass, viewShortcuts);
     }
-    viewShortcuts.put(createSerializedKey(keyCode, modifiers), callback);
+    RegisteredShortcut<T> shortcut = new RegisteredShortcut<T>(name, viewClass, defaultKey, callback);
+    shortcut.currentKey = overrides.getOrDefault(name, defaultKey);
+    byActionId.put(name, shortcut);
+    viewShortcuts.put(shortcut.currentKey, callback);
+  }
+
+  /**
+   * Replaces the cached key overrides and moves every already-registered
+   * shortcut's entry in {@code registry} to match, patching the dispatch map
+   * in place rather than rebuilding it. Safe to call at any time (app startup
+   * and again whenever the user saves a remap) — a shortcut whose resolved
+   * key hasn't changed is left untouched.
+   *
+   * @param newOverrides a map of actionId to serialized key string, as returned
+   *     by {@link #loadKeyOverrides()}
+   */
+  public void applyKeyOverrides(Map<String, String> newOverrides) {
+    this.overrides = new HashMap<String, String>(newOverrides);
+    for (RegisteredShortcut<?> shortcut : byActionId.values()) {
+      String newKey = overrides.getOrDefault(shortcut.actionId, shortcut.defaultKey);
+      if (newKey.equals(shortcut.currentKey)) {
+        continue;
+      }
+      Map<String, Function<?, Boolean>> viewShortcuts = registry.get(shortcut.viewClass);
+      viewShortcuts.remove(shortcut.currentKey);
+      viewShortcuts.put(newKey, shortcut.callback);
+      shortcut.currentKey = newKey;
+    }
+  }
+
+  /**
+   * Looks up whether {@code candidateKey} is already bound, within
+   * {@code actionId}'s own scope, to a different shortcut.
+   *
+   * @return the actionId of the conflicting shortcut, or {@code null} if
+   *     there's no conflict — including when {@code actionId} isn't (yet)
+   *     live-registered, since remapping it currently has no dispatch effect
+   */
+  public String findConflict(String actionId, String candidateKey) {
+    RegisteredShortcut<?> mine = byActionId.get(actionId);
+    if (mine == null) {
+      return null;
+    }
+    for (RegisteredShortcut<?> entry : byActionId.values()) {
+      if (entry.viewClass == mine.viewClass && !entry.actionId.equals(actionId)
+          && entry.currentKey.equals(candidateKey)) {
+        return entry.actionId;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the callback a live keydown with this serialized key would
+   * dispatch to, using the same view-class walk as {@link #onKeyDown}.
+   * Package-visible for unit tests, which can't construct a real
+   * {@link KeyDownEvent} outside a browser.
+   */
+  Function<?, Boolean> resolveDispatch(Class<?> viewClass, String serializedKey) {
+    Map<String, Function<?, Boolean>> viewShortcuts = null;
+    while (viewShortcuts == null && viewClass != Widget.class) {
+      viewShortcuts = registry.get(viewClass);
+      viewClass = viewClass.getSuperclass();
+    }
+    return viewShortcuts == null ? null : viewShortcuts.get(serializedKey);
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/appinventor/appengine/tests/com/google/appinventor/client/utils/ShortcutRegistryTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/utils/ShortcutRegistryTest.java
@@ -1,0 +1,106 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.utils;
+
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Label;
+
+import junit.framework.TestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Checks that {@link ShortcutRegistry} applies key overrides to live dispatch,
+ * regardless of whether the override is known before or after a shortcut is
+ * registered, and that same-scope key collisions are detected.
+ *
+ * <p>Registration here goes through {@link ShortcutRegistry#registerWithDefaultKey}
+ * rather than the public {@code registerViewShortcut}, since the latter computes
+ * its default key via a JSNI call into Blockly that has no JVM body outside a
+ * browser/GWTTestCase environment. The override/dispatch/conflict logic under
+ * test here is plain Java with no such dependency.
+ *
+ * <p>Tests scope shortcuts to concrete {@code Widget} subclasses ({@link Label},
+ * {@link Composite}) rather than {@code Widget.class} itself, matching how
+ * production code always scopes registrations to a specific view class —
+ * {@code Widget.class} is deliberately excluded from the dispatch walk's own
+ * loop condition and would never resolve.
+ */
+public class ShortcutRegistryTest extends TestCase {
+
+  private ShortcutRegistry registry;
+
+  @Override
+  protected void setUp() {
+    registry = new ShortcutRegistry();
+  }
+
+  private static <T> Function<T, Boolean> noop() {
+    return t -> true;
+  }
+
+  private static Map<String, String> overridesOf(String actionId, String key) {
+    Map<String, String> overrides = new HashMap<String, String>();
+    overrides.put(actionId, key);
+    return overrides;
+  }
+
+  public void testOverrideKnownBeforeRegistrationIsUsedImmediately() {
+    registry.applyKeyOverrides(overridesOf("focus_tree", "Alt+84"));
+    registry.registerWithDefaultKey(Label.class, "focus_tree", "Alt+70", ShortcutRegistryTest.<Label>noop());
+
+    assertNotNull(registry.resolveDispatch(Label.class, "Alt+84"));
+    assertNull(registry.resolveDispatch(Label.class, "Alt+70"));
+  }
+
+  public void testOverrideAppliedAfterRegistrationMovesDispatchEntry() {
+    registry.registerWithDefaultKey(Label.class, "focus_tree", "Alt+70", ShortcutRegistryTest.<Label>noop());
+    assertNotNull(registry.resolveDispatch(Label.class, "Alt+70"));
+
+    registry.applyKeyOverrides(overridesOf("focus_tree", "Alt+84"));
+
+    assertNotNull(registry.resolveDispatch(Label.class, "Alt+84"));
+    assertNull(registry.resolveDispatch(Label.class, "Alt+70"));
+  }
+
+  public void testDroppingOverrideRevertsToDefaultKey() {
+    registry.registerWithDefaultKey(Label.class, "focus_tree", "Alt+70", ShortcutRegistryTest.<Label>noop());
+    registry.applyKeyOverrides(overridesOf("focus_tree", "Alt+84"));
+    assertNotNull(registry.resolveDispatch(Label.class, "Alt+84"));
+
+    // A diff-only overrides map with no entry for focus_tree means "back to default".
+    registry.applyKeyOverrides(new HashMap<String, String>());
+
+    assertNull(registry.resolveDispatch(Label.class, "Alt+84"));
+    assertNotNull(registry.resolveDispatch(Label.class, "Alt+70"));
+  }
+
+  public void testFindConflictDetectsSameScopeCollision() {
+    registry.registerWithDefaultKey(Label.class, "focus_tree", "Alt+84", ShortcutRegistryTest.<Label>noop());
+    registry.registerWithDefaultKey(Label.class, "focus_viewer", "Alt+86", ShortcutRegistryTest.<Label>noop());
+
+    assertEquals("focus_tree", registry.findConflict("focus_viewer", "Alt+84"));
+    assertNull(registry.findConflict("focus_viewer", "Alt+86")); // its own current key
+    assertNull(registry.findConflict("focus_viewer", "Alt+99")); // unused key
+  }
+
+  public void testFindConflictIgnoresDifferentScope() {
+    registry.registerWithDefaultKey(Label.class, "focus_tree", "Alt+84", ShortcutRegistryTest.<Label>noop());
+    registry.registerWithDefaultKey(Composite.class, "select_all_projects", "Alt+84", ShortcutRegistryTest.<Composite>noop());
+
+    assertNull(registry.findConflict("select_all_projects", "Alt+84"));
+  }
+
+  public void testFindConflictReturnsNullForUnregisteredAction() {
+    registry.registerWithDefaultKey(Label.class, "focus_tree", "Alt+84", ShortcutRegistryTest.<Label>noop());
+
+    // "refresh_companion" isn't registered (not yet migrated onto the registry),
+    // so remapping it can't conflict with anything live.
+    assertNull(registry.findConflict("refresh_companion", "Alt+84"));
+  }
+}


### PR DESCRIPTION
Rewire shortcuts from registry's storage when needed. Adds unit tests but had to expose a method, so happy to also remove the test class. It only deals with designer shortcuts we want to manage first and marks a few more as not remappable, so the root panel and other parts of the code still register things that are not yet in the registry. It also checks for conflicts with other current shortcuts and stops the user from remapping.